### PR TITLE
Add canary-flash models

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ ctrlSPEAK uses open-source speech recognition models:
 
 - **Parakeet 0.6B** (default): NVIDIA NeMo's `nvidia/parakeet-tdt-0.6b-v2` model. Good balance of speed, accuracy, punctuation, and capitalization.
 - **Parakeet 1.1B**: NVIDIA NeMo's older `nvidia/parakeet-tdt-1.1b` model. Potentially higher accuracy in some cases, but lacks punctuation.
-- **Canary**: NVIDIA NeMo's `nvidia/canary-1b` multilingual model (En, De, Fr, Es) with punctuation, but can be slower.
+- **Canary**: NVIDIA NeMo's `nvidia/canary-1b-flash` multilingual model (En, De, Fr, Es) with punctuation, but can be slower.
+- **Canary**: NVIDIA NeMo's `nvidia/canary-180m-flash` multilingual model (En, De, Fr, Es) with punctuation, very small and less accurate.
 - **Whisper** (optional): OpenAI's `openai/whisper-large-v3-turbo` model. Fast and accurate general-purpose model.
   - To use Whisper, install additional dependencies: `uv pip install -r requirements-whisper.txt`
 
@@ -127,16 +128,19 @@ You can specify which model to use with the `--model` flag:
 ctrlspeak --model parakeet-0.6b  # Default
 ctrlspeak --model parakeet-1.1b  # Older, larger Parakeet
 ctrlspeak --model canary         # Multilingual with punctuation
+ctrlspeak --model canary-180m    # Multilingual with punctuation, small
 ctrlspeak --model whisper        # OpenAI's model
 
 # Using manual installation
 python ctrlspeak.py --model parakeet-0.6b
 python ctrlspeak.py --model parakeet-1.1b
 python ctrlspeak.py --model canary
+python ctrlspeak.py --model canary-180m
 python ctrlspeak.py --model whisper
 ```
 
 For debugging, you can use the `--debug` flag:
+
 ```bash
 ctrlspeak --debug
 ```
@@ -145,8 +149,9 @@ ctrlspeak --debug
 
 1. **Parakeet 0.6B (NVIDIA)** - `nvidia/parakeet-tdt-0.6b-v2` (Default)
 2. **Parakeet 1.1B (NVIDIA)** - `nvidia/parakeet-tdt-1.1b`
-3. **Canary (NVIDIA)** - `nvidia/canary-1b`
-4. **Whisper (OpenAI)** - `openai/whisper-large-v3-turbo`
+3. **Canary (NVIDIA)** - `nvidia/canary-1b-flash`
+4. **Canary (NVIDIA)** - `nvidia/canary-180m-flash`
+5. **Whisper (OpenAI)** - `openai/whisper-large-v3-turbo`
 
 ## Performance Comparison
 

--- a/ctrlspeak.py
+++ b/ctrlspeak.py
@@ -121,8 +121,8 @@ logging.basicConfig(
 logger = logging.getLogger("ctrlspeak")
 
 # Silence all the noisy libraries
-for lib in ['matplotlib', 'numba', 'urllib3', 'nemo', 'nemo_logger', 
-           'nemo.collections', 'pytorch_lightning', 'filelock', 
+for lib in ['matplotlib', 'numba', 'urllib3', 'nemo', 'nemo_logger',
+           'nemo.collections', 'pytorch_lightning', 'filelock',
            'huggingface_hub', 'transformers', 'sound_player']:
     logging.getLogger(lib).setLevel(logging.CRITICAL)
     # Also apply our filter to each logger
@@ -132,7 +132,8 @@ for lib in ['matplotlib', 'numba', 'urllib3', 'nemo', 'nemo_logger',
 MODEL_CACHE_MAP = {
     "models--nvidia--parakeet-tdt-0.6b-v2": "parakeet-0.6b",
     "models--nvidia--parakeet-tdt-1.1b": "parakeet-1.1b",
-    "models--nvidia--canary-1b": "canary",
+    "models--nvidia--canary-1b-flash": "canary",
+    "models--nvidia--canary-180m-flash": "canary-180m",
     "models--openai--whisper-large-v3-turbo": "whisper",
     # Add other models if supported in the future
 }
@@ -507,7 +508,7 @@ def parse_arguments():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="ctrlSPEAK - Speech-to-text transcription tool")
     parser.add_argument("--model", type=str, 
-                        choices=["parakeet", "parakeet-0.6b", "parakeet-1.1b", "canary", "whisper"], # Allow generic parakeet here
+                        choices=["parakeet", "parakeet-0.6b", "parakeet-1.1b", "canary", "canary-180m", "whisper"], # Allow generic parakeet here
                         default=get_preferred_model(),
                         help="Speech recognition model to use (default: %(default)s)")
     parser.add_argument("--debug", action="store_true", 

--- a/models/canary.py
+++ b/models/canary.py
@@ -13,9 +13,10 @@ from typing import List
 logger = logging.getLogger("canary_model")
 
 class CanaryModel(BaseSTTModel):
-    """Canary 1B model for multilingual speech-to-text and translation."""
-    
-    def __init__(self, model_name="nvidia/canary-1b", device=None, verbose=False):
+    """Canary model for multilingual speech-to-text and translation.
+    Defaults to 'nvidia/canary-1b-flash' if no model_name is specified."""
+
+    def __init__(self, model_name="nvidia/canary-1b-flash", device=None, verbose=False):
         """Initialize the Canary model.
         
         Args:
@@ -68,9 +69,6 @@ class CanaryModel(BaseSTTModel):
             decode_cfg = self.model.cfg.decoding
             decode_cfg.strategy = 'beam'
             decode_cfg.beam.beam_size = 1
-            decode_cfg.beam.return_best_hypothesis = True
-            decode_cfg.preserve_alignments = None
-            decode_cfg.compute_langs = False
             self.model.change_decoding_strategy(decode_cfg)
             
             # Convert model to float32 before device placement

--- a/models/canary.py
+++ b/models/canary.py
@@ -138,7 +138,7 @@ class CanaryModel(BaseSTTModel):
             logger.debug(f"Transcription completed in {transcribe_time:.2f} seconds")
             
             # Clean up each result
-            transcriptions = [self._clean_text(text) for text in raw_result]
+            transcriptions = [self._clean_text(text.text) for text in raw_result]
             
             end_time = time.time()
             logger.info(f"Transcription completed in {end_time - start_time:.2f} seconds")

--- a/models/factory.py
+++ b/models/factory.py
@@ -5,7 +5,6 @@ from models.parakeet import ParakeetModel
 from models.canary import CanaryModel
 import logging
 import importlib.util
-import sys
 
 # Configure logging
 logger = logging.getLogger("model_factory")
@@ -65,8 +64,11 @@ class ModelFactory:
             logger.debug("Initializing ParakeetModel with nvidia/parakeet-tdt-1.1b")
             return ParakeetModel(model_name="nvidia/parakeet-tdt-1.1b", **kwargs)
         elif model_type == "canary":
-            logger.debug("Initializing CanaryModel")
-            return CanaryModel(**kwargs)
+            logger.debug("Initializing CanaryModel (defaulting to nvidia/canary-1b-flash)")
+            return CanaryModel(**kwargs) # CanaryModel now defaults to 1b-flash
+        elif model_type == "canary-180m":
+            logger.debug("Initializing CanaryModel with nvidia/canary-180m-flash")
+            return CanaryModel(model_name="nvidia/canary-180m-flash", **kwargs)
         elif model_type == "whisper":
             # Check if Whisper dependencies are installed
             if importlib.util.find_spec("transformers") is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ soundfile
 # UI and system integration
 pynput     # For keyboard shortcuts
 pyperclip  # For clipboard operations
-rich>=13.6.0  # For terminal UI 
+rich>=13.6.0  # For terminal UI


### PR DESCRIPTION
This adds the canary-flash models, there are a few existing issues but I wasn't sure if these existed before. There were a few parameters that are now depreciated like `return_best_hypothesis` which required me to access `.text` on the transcription result.

There is also some oddity with canary models where the imports happen a second time?


```
❯ python ctrlspeak.py --model canary-180m
Starting imports... 0.00s
Basic imports done... 0.60s
UI imports done... 0.63s
Starting torch import... 0.63s
Torch imported... 1.41s
Starting app imports... 1.41s
All imports done... 5.94s

Model Configuration:
  Selected: canary-180m
  Status: Found in cache
  Other cached models available: canary, parakeet-0.6b

Step 1 of 2: Checking microphone access...
Checking microphone permissions...
✓ Microphone permissions granted
✓ Microphone access is granted.

Step 2 of 2: Checking keyboard monitoring permissions...
Checking keyboard monitoring permissions...
Running from: ghostty
Using macOS Accessibility API directly...
✓ Accessibility permissions granted (via AXIsProcessTrusted)

All required permissions are granted! Starting ctrlSPEAK...
ctrlSPEAK - Speech recognition ready
╭──────────── Welcome ─────────────╮
│ ctrlSPEAK - Ready to transcribe. │
╰─ Model: canary-180m (Loading...)─╯

Loading model... please wait
Model loaded in 3.29 seconds. Ready to record!

╭──────────────────────────────────────╮
│ Started recording...                 │
│ Tap Ctrl key 3 times quickly to stop │
╰──────────────────────────────────────╯
Recording 00:10 ● (0.7s of audio)

Transcribing: 0it [00:00, ?it/s]Starting imports... 0.00s
Basic imports done... 0.50s
UI imports done... 0.53s
Starting torch import... 0.53s
Torch imported... 1.29s
Starting app imports... 1.29s
All imports done... 6.01s
Transcribing: 1it [00:13, 13.00s/it]
No transcription result
```